### PR TITLE
Hungarian-magyar-hu implemented as an applicable language.

### DIFF
--- a/R/get_transliterations.R
+++ b/R/get_transliterations.R
@@ -11,6 +11,7 @@ get_transliterations <- function(language = c("armenian", "հայերէն", "հ�
                                               "georgian", "kartuli", "ქართული", "ka",
                                               "german", "deutsch", "deutsche Sprache", "de",
                                               "greek", "ελληνικά",  "el",
+                                              "hungarian", "magyar", "hu",
                                               "norwegian", "norsk", "no",
                                               "polish", "język polski", "pl",
                                               "romanian", "limba română", "ro",
@@ -191,6 +192,30 @@ get_transliterations <- function(language = c("armenian", "հայերէն", "հ�
     return(transliterations_el)
   }
 
+  # Hungarian -- Simple mapping of characters with diacritics into the
+  #              same character without a diacritic. This includes chars
+  #              used to represent double acutes in unconventional ways, 
+  #              e.g. using a chapeau or a tilde.
+  #              The a with umlaut (ä/Ä) is not quintessentially a Hungarian
+  #              linguistic feature, but it does occur very frequently in names
+  #              of geographic features and personalities to this date, and is
+  #              therefore included.
+  if (any(c("hungarian", "magyar", "hu") %in% language)){
+    transliterations_hu <- 
+      data.frame(from = c("Á", "á", "Ä", "ä", "É", "é",
+                          "Í", "í", "Ó", "ó", "Ő", "ő",
+                          "Ô", "ô", "Õ", "õ", "Ú", "ú",
+                          "Ű", "ű", "Û", "Ũ", "ũ"),
+                 to = c("A", "a", "A", "a", "E", "e", 
+                        "I", "i", "O", "o", "O", "o", 
+                        "O", "o", "O", "O", "U", "u", 
+                        "U", "u", "U", "U", "u"),
+                 type = rep("hu"), stringsAsFactors = FALSE)
+    return(transliterations_hu) 
+  }
+    
+  
+  
   # Norwegian -- Simple mapping of ligature characters and those with
   #              diacritics
   if (any(c("norwegian", "norsk", "no") %in% language)){

--- a/README.md
+++ b/README.md
@@ -297,6 +297,26 @@ Giorgos Seferis's *The King of Asine* (1938)
 
 ```
 
+### Hungarian // magyar // hu
+
+Sándor Márai's *Hol vagyok? (Where am I?)* (1972)
+
+```
+
+Ülök a padon, nézem az eget                           % -> Ulok a padon, nezem az eget. 
+A Central Park nem a Margitsziget.                    % -> A Central Park nem a Margitsziget.
+Milyen szép az élet, - kapok, amit kérek.             % -> Milyen szep az elet, - kapok, amit kerek.
+Milyen furcsa íze van itt a kenyérnek.                % -> Milyen furcsa ize van itt a kenyernek.
+Micsoda házak és micsoda utak!                        % -> Micsoda hazak es micsoda utak!
+Vajon, hogy hívják most a Károly körutat?             % -> Vajon, hogy hivjak most a Karoly korutat?
+Micsoda nép! - az iramot bírják.                      % -> Micsoda nep! - az iramot birjak.
+Vajon ki ápolja szegény Mama sírját?                  % -> Vajon ki apolja szegeny Mama sirjat?
+Izzik a levegő, a Nap ragyog.                         % -> Izzik a levego, a Nap ragyog.
+Szent Isten! - hol vagyok?                            % -> Szent Isten! - hol vagyok?
+
+```
+
+
 ### Polish // język polski // pl
 
 Szymborska Wisława's *Utopia* (1976)

--- a/inst/examples/Hol_vagyok__hu.txt
+++ b/inst/examples/Hol_vagyok__hu.txt
@@ -1,0 +1,10 @@
+Ülök a padon, nézem az eget. 
+A Central Park nem a Margitsziget.
+Milyen szép az élet,-kapok, amit kérek.
+Milyen furcsa íze van itt a kenyérnek.
+Micsoda házak és micsoda utak!
+Vajon, hogy hívják most a Károly körutat?
+Micsoda nép! - az iramot bírják.
+Vajon ki ápolja szegény Mama sírját?
+Izzik a levegő, a Nap ragyog.
+Szent Isten! - hol vagyok?


### PR DESCRIPTION
This PR adds Hungarian as an applicable language. Principally, the following features are implemented:

* Both standard (ISO-8859-1) and western1 characters for long acute (double acute) vowels are implemented, to deal with situations where e.g. o-tilde is used to represent o-double-acute
* A/a with umlaut is implemented as part of Hungarian due to the number of proper names that contain a with umlaut
* Sample transliteration poem (by Sándor Márai) added.

Hungarian responds, like most other languages, to its English name (`hungarian`), its ISO code (`hu`) and its internal name (`magyar`).